### PR TITLE
Update lombok to newer version compatible with Java module and Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 before_install: 
   - mvn clean
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
       <jackson.version>2.8.1</jackson.version>
       <slf4j.version>1.7.21</slf4j.version>
       <httpclient.version>4.3.3</httpclient.version>
-      <lombok.version>1.16.2</lombok.version>
+      <lombok.version>1.18.6</lombok.version>
    </properties>
 
    <modules>


### PR DESCRIPTION
Compile error when using the latest JDKs, since lombok was using a sun package now hidden with Java modules.  Corrected implemented in newer lombok version updated in POM.

Pushed with force post rebase to move the Travis-CI commit fix above the POM fix, and both are now reporting "ok" on Travis-CI