### PR TITLE
Bumping the versions of dependencies.

### DIFF
--- a/ig-webapi-java-client/pom.xml
+++ b/ig-webapi-java-client/pom.xml
@@ -28,7 +28,7 @@
       </dependency>
 
       <dependency>
-         <groupId>org.apache.commons</groupId>
+         <groupId>commons-io</groupId>
          <artifactId>commons-io</artifactId>
       </dependency>
 

--- a/ig-webapi-java-sample-console-ui/pom.xml
+++ b/ig-webapi-java-sample-console-ui/pom.xml
@@ -16,7 +16,7 @@
    <artifactId>ig-webapi-java-sample-console-ui</artifactId>
 
    <properties>
-      <spring-boot.version>1.4.0.RELEASE</spring-boot.version>
+      <spring-boot.version>2.7.5</spring-boot.version>
    </properties>
 
    <dependencyManagement>

--- a/ig-webapi-java-sample-console/pom.xml
+++ b/ig-webapi-java-sample-console/pom.xml
@@ -16,7 +16,7 @@
    <artifactId>ig-webapi-java-sample-console</artifactId>
 
    <properties>
-      <spring-boot.version>1.4.0.RELEASE</spring-boot.version>
+      <spring-boot.version>2.7.5</spring-boot.version>
    </properties>
 
    <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
       <java.version>1.8</java.version>
 
       <lightstreamer.version>6.0.2.20160510</lightstreamer.version>
-      <spring.version>4.3.2.RELEASE</spring.version>
-      <commons-io.version>1.3.2</commons-io.version>
-      <jackson.version>2.12.1</jackson.version>
+      <spring.version>5.3.23</spring.version>
+      <commons-io.version>2.11.0</commons-io.version>
+      <jackson.version>2.13.4</jackson.version>
       <slf4j.version>1.7.21</slf4j.version>
       <httpclient.version>4.5.13</httpclient.version>
-      <lombok.version>1.18.6</lombok.version>
+      <lombok.version>1.18.24</lombok.version>
    </properties>
 
    <modules>
@@ -50,7 +50,7 @@
          </dependency>
 
          <dependency>
-            <groupId>org.apache.commons</groupId>
+            <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commons-io.version}</version>
          </dependency>


### PR DESCRIPTION
Bumping the versions of dependencies as I couldn't get the project to compile without it.

The Apache Commons IO libraries are now managed under the "commons-io" groupId.
Previously: https://mvnrepository.com/artifact/org.apache.commons/commons-io
Now: https://mvnrepository.com/artifact/commons-io/commons-io